### PR TITLE
ci(deploy): diffに関係なくデプロイを実行する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,13 +15,7 @@ jobs:
             name: Production
         steps:
             - uses: actions/checkout@v3
-            - uses: ./actions/diff
-              name: diff
-              id: diff
-              with:
-                  subdir: src
             - name: Connect to Server
-              if: steps.diff.outputs.diff-count > 0
               uses: appleboy/ssh-action@v0.1.9
               with:
                   host: ${{secrets.HOST_NAME}}

--- a/actions/diff/action.yml
+++ b/actions/diff/action.yml
@@ -18,10 +18,6 @@ runs:
           run: |
               git fetch origin ${TARGET_BRANCH}
               git fetch origin ${HEAD_BRANCH}
-              echo ${TARGET_BRANCH} ${HEAD_BRANCH}
-              git branch -a
-              git log origin/${TARGET_BRANCH} -n 1
-              git log origin/${HEAD_BRANCH} -n 1
               count=`git diff origin/${TARGET_BRANCH} origin/${HEAD_BRANCH} --name-only --relative=${{ inputs.subdir }} | wc -l`
               echo "::set-output name=diff-count::$(echo $count)"
           shell: bash


### PR DESCRIPTION
`closed`イベントだとすでにマージされていてブランチ間のdiffが同じになってしまうため